### PR TITLE
Design R2: distinctive type, glass content, motion craft, grid-breaking hero

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/(public)/page.tsx
+++ b/Source/Client/src/app/(public)/page.tsx
@@ -5,6 +5,8 @@ import { ArrowDown, ArrowRight, ArrowUpRight } from "lucide-react";
 
 import { Reveal } from "@/components/reveal";
 import { QuotesMarquee, type Quote } from "@/components/quotes-marquee";
+import { HeroAstronaut } from "@/components/hero-astronaut";
+import { MagneticButton } from "@/components/magnetic-button";
 
 type Principle = { label: string; description: string };
 
@@ -204,13 +206,13 @@ gtag('config', 'G-VZ3GBPF421');`}
           className="pointer-events-none absolute left-[16%] bottom-16 hidden h-6 w-6 animate-float-slower opacity-50 dark:invert lg:block"
         />
 
-        <div className="container relative grid min-h-[88vh] items-center gap-10 py-24 md:py-32 lg:grid-cols-[1.05fr_0.95fr] lg:gap-6">
-          <div>
+        <div className="container relative grid min-h-[88vh] items-center gap-6 py-24 md:py-32 lg:grid-cols-[1.05fr_0.95fr] lg:gap-0">
+          <div className="relative z-10">
             <Reveal>
               <Eyebrow>The Push Manifesto</Eyebrow>
             </Reveal>
             <Reveal delay={0.05}>
-              <h1 className="mt-6 max-w-2xl font-display text-[clamp(2.75rem,7vw,5.5rem)] font-semibold leading-[0.98] tracking-[-0.02em]">
+              <h1 className="mt-6 max-w-2xl font-display text-[clamp(2.75rem,7.5vw,6rem)] font-bold leading-[0.95] tracking-[-0.03em]">
                 A way to do{" "}
                 <span className="text-gradient-brand">creativity</span>.
               </h1>
@@ -226,15 +228,15 @@ gtag('config', 'G-VZ3GBPF421');`}
             </Reveal>
             <Reveal delay={0.15}>
               <div className="mt-10 flex flex-wrap items-center gap-3">
-                <Link
+                <MagneticButton
                   href="#manifesto"
-                  className="group inline-flex items-center gap-3 rounded-full bg-gradient-brand py-3 pl-6 pr-3 text-sm font-medium text-white shadow-lg shadow-[#e73c6f]/20 transition-transform duration-300 active:scale-[0.98]"
+                  className="group inline-flex items-center gap-3 rounded-full bg-gradient-brand py-3 pl-6 pr-3 text-sm font-medium text-white shadow-lg shadow-[#e73c6f]/25 transition-transform duration-300 active:scale-[0.97]"
                 >
                   Read the manifesto
                   <span className="grid h-8 w-8 place-items-center rounded-full bg-white/25 transition-transform duration-300 group-hover:translate-y-0.5">
                     <ArrowDown className="h-4 w-4" />
                   </span>
-                </Link>
+                </MagneticButton>
                 <Link
                   href="/blog"
                   className="group glass inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-medium text-foreground transition-colors duration-300 hover:bg-foreground/5"
@@ -246,22 +248,11 @@ gtag('config', 'G-VZ3GBPF421');`}
             </Reveal>
           </div>
 
-          {/* The original Push Manifesto "space cowboy" — drifting through the hero. */}
-          <Reveal delay={0.15} className="relative justify-self-center">
-            <div
-              aria-hidden
-              className="absolute left-1/2 top-1/2 -z-10 h-[420px] w-[420px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-40 blur-3xl"
-              style={{
-                background:
-                  "radial-gradient(circle at center, rgba(35,148,213,0.5), rgba(42,243,183,0.25) 45%, transparent 70%)",
-              }}
-            />
-            <img
-              src="/img/manifesto.png"
-              alt="The Push Manifesto astronaut, drifting through space"
-              className="mx-auto w-[260px] animate-float-slow drop-shadow-2xl sm:w-[340px] lg:w-[440px] dark:invert"
-            />
-          </Reveal>
+          {/* The "space cowboy" breaks the grid — larger, pulled left to drift
+              behind the headline, with scroll parallax. */}
+          <div className="pointer-events-none relative z-0 -mt-6 lg:-ml-28 lg:mt-0 xl:-ml-44">
+            <HeroAstronaut />
+          </div>
         </div>
       </section>
 
@@ -276,8 +267,8 @@ gtag('config', 'G-VZ3GBPF421');`}
               </h2>
             </div>
           </Reveal>
-          <div className="space-y-6">
-            <Reveal delay={0.05}>
+          <Reveal delay={0.05}>
+            <div className="glass space-y-6 rounded-3xl p-8 shadow-[0_24px_60px_-32px_rgba(0,0,0,0.5)] md:p-12">
               <p className="text-xl leading-relaxed text-foreground/90 md:text-2xl">
                 <strong className="font-semibold">Push Manifesto</strong> is about
                 vision, collaboration, inclusive behaviours, determination,
@@ -287,15 +278,14 @@ gtag('config', 'G-VZ3GBPF421');`}
                 fit-for-purpose with shared value outcomes for users and
                 stakeholders.
               </p>
-            </Reveal>
-            <Reveal delay={0.1}>
+              <div className="h-px bg-gradient-to-r from-border via-border/40 to-transparent" />
               <p className="text-lg leading-relaxed text-muted-foreground">
                 It feeds the Maturity Model and an evidence-based mindset,
                 supporting the scientific approach — daring to explore the latent
                 space, with a pragmatic world-view.
               </p>
-            </Reveal>
-          </div>
+            </div>
+          </Reveal>
         </div>
       </section>
 
@@ -309,27 +299,27 @@ gtag('config', 'G-VZ3GBPF421');`}
             </h2>
           </Reveal>
 
-          <ol className="mt-14 grid gap-x-12 gap-y-px sm:grid-cols-2">
+          <ol className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {principles.map((p, i) => (
-              <Reveal as="li" key={p.label} delay={(i % 2) * 0.05}>
+              <Reveal as="li" key={p.label} delay={(i % 3) * 0.08}>
                 <a
                   href={tweetHref(`${p.label}: ${p.description.replace(/[*_]/g, "")}`)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex gap-5 border-t border-border/60 py-7 transition-colors duration-300 hover:border-foreground/30"
+                  className="group glass flex h-full flex-col gap-3 rounded-2xl p-6 transition-all duration-300 hover:-translate-y-1.5 hover:shadow-[0_24px_50px_-28px_rgba(0,0,0,0.55)]"
                 >
-                  <span className="font-mono text-sm tabular-nums text-muted-foreground/70 transition-colors group-hover:text-[#e73c6f]">
-                    {String(i + 1).padStart(2, "0")}
-                  </span>
-                  <div className="space-y-2">
-                    <h3 className="flex items-center gap-1.5 font-display text-xl font-medium tracking-tight">
-                      {p.label}
-                      <ArrowUpRight className="h-4 w-4 -translate-y-px text-muted-foreground/0 transition-all duration-300 group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
-                    </h3>
-                    <p className="text-[15px] leading-relaxed text-muted-foreground">
-                      {emphasise(p.description)}
-                    </p>
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-sm tabular-nums text-muted-foreground/70 transition-colors group-hover:text-[#e73c6f]">
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <ArrowUpRight className="h-4 w-4 text-muted-foreground/0 transition-all duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
                   </div>
+                  <h3 className="font-display text-lg font-semibold tracking-tight">
+                    {p.label}
+                  </h3>
+                  <p className="text-[14px] leading-relaxed text-muted-foreground">
+                    {emphasise(p.description)}
+                  </p>
                 </a>
               </Reveal>
             ))}

--- a/Source/Client/src/app/layout.tsx
+++ b/Source/Client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Fraunces } from "next/font/google";
+import { Bricolage_Grotesque } from "next/font/google";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { Analytics } from "@vercel/analytics/next";
@@ -8,10 +8,11 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ThemeProvider } from "@/components/theme-provider";
 import "@/styles/globals.css";
 
-const fraunces = Fraunces({
+const display = Bricolage_Grotesque({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-display",
+  weight: ["400", "500", "600", "700", "800"],
 });
 
 export const metadata: Metadata = {
@@ -48,7 +49,7 @@ export default function RootLayout({
       lang="en"
       translate="no"
       suppressHydrationWarning
-      className={`${GeistSans.variable} ${GeistMono.variable} ${fraunces.variable}`}
+      className={`${GeistSans.variable} ${GeistMono.variable} ${display.variable}`}
     >
       <body translate="no" className="font-sans">
         <ThemeProvider

--- a/Source/Client/src/components/hero-astronaut.tsx
+++ b/Source/Client/src/components/hero-astronaut.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRef } from "react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useReducedMotion,
+} from "framer-motion";
+
+/**
+ * The Push Manifesto "space cowboy" — drifts continuously (CSS float),
+ * parallax-shifts and rotates gently as the hero scrolls away, and rides a
+ * blue/teal glow. Transforms are split across nested elements so the scroll
+ * parallax and the continuous float never fight over `transform`.
+ */
+export function HeroAstronaut() {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], [0, 140]);
+  const rotate = useTransform(scrollYProgress, [0, 1], [0, 7]);
+  const opacity = useTransform(scrollYProgress, [0, 0.85], [1, 0.4]);
+
+  return (
+    <div ref={ref} className="relative">
+      <div
+        aria-hidden
+        className="absolute left-1/2 top-1/2 -z-10 h-[460px] w-[460px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-60 blur-3xl"
+        style={{
+          background:
+            "radial-gradient(circle at center, rgba(35,148,213,0.55), rgba(42,243,183,0.28) 45%, transparent 70%)",
+        }}
+      />
+      <motion.div style={reduce ? undefined : { y, rotate, opacity }}>
+        <div className="animate-float-slow">
+          <img
+            src="/img/manifesto.png"
+            alt="The Push Manifesto astronaut, drifting through space"
+            className="mx-auto w-[280px] drop-shadow-2xl sm:w-[360px] lg:w-[480px] dark:invert"
+          />
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/Source/Client/src/components/magnetic-button.tsx
+++ b/Source/Client/src/components/magnetic-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import {
+  motion,
+  useMotionValue,
+  useSpring,
+  useReducedMotion,
+} from "framer-motion";
+
+type MagneticButtonProps = {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  external?: boolean;
+  /** How strongly the button leans toward the cursor (0–1). */
+  strength?: number;
+};
+
+/**
+ * A link that gently leans toward the cursor while hovered, then springs back.
+ * Respects reduced-motion (renders a plain anchor with no tracking).
+ */
+export function MagneticButton({
+  href,
+  children,
+  className,
+  external,
+  strength = 0.35,
+}: MagneticButtonProps) {
+  const ref = React.useRef<HTMLAnchorElement>(null);
+  const reduce = useReducedMotion();
+  const mx = useMotionValue(0);
+  const my = useMotionValue(0);
+  const x = useSpring(mx, { stiffness: 220, damping: 16, mass: 0.4 });
+  const y = useSpring(my, { stiffness: 220, damping: 16, mass: 0.4 });
+
+  function onMove(e: React.MouseEvent<HTMLAnchorElement>) {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    mx.set((e.clientX - (r.left + r.width / 2)) * strength);
+    my.set((e.clientY - (r.top + r.height / 2)) * strength);
+  }
+  function reset() {
+    mx.set(0);
+    my.set(0);
+  }
+
+  return (
+    <motion.a
+      ref={ref}
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      onMouseMove={reduce ? undefined : onMove}
+      onMouseLeave={reset}
+      style={reduce ? undefined : { x, y }}
+      className={className}
+    >
+      {children}
+    </motion.a>
+  );
+}


### PR DESCRIPTION
Second design pass on top of v1.0.0. Production is untouched until this merges.

- **Type** — swapped Fraunces (a training-default the skills flag) for **Bricolage Grotesque**: bolder, more distinctive display voice.
- **Glass depth across content** — the Manifesto block is now a frosted panel with a gradient divider; the 12 principles are **glass tiles** in a 3-col grid with hover lift.
- **Motion craft** — astronaut gains **scroll parallax + rotate + fade** over its float; the primary CTA is a **magnetic** button (leans toward the cursor); principle reveals **stagger** per row. All respect `prefers-reduced-motion`.
- **Grid-breaking hero** — bigger/bolder headline; the astronaut is pulled left and larger, **drifting behind the headline**.

Verified: `npm run build` green; hero + Manifesto panel screenshotted locally. Best reviewed live (scroll for the staggered glass tiles + parallax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)