### PR TITLE
a11y (WCAG/ARIA) pass + wisejnrs.net mobile menu popup

### DIFF
--- a/Source/Client/src/app/(public)/layout.tsx
+++ b/Source/Client/src/app/(public)/layout.tsx
@@ -19,7 +19,7 @@ export default function SiteLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="flex min-h-[100dvh] flex-col">
       <SiteHeader />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" className="flex-1">{children}</main>
       <SiteFooter />
     </div>
   );

--- a/Source/Client/src/app/blog/[slug]/blog-post-client.tsx
+++ b/Source/Client/src/app/blog/[slug]/blog-post-client.tsx
@@ -307,8 +307,7 @@ export default function BlogPostClient({ post, allPosts = [] }: BlogPostClientPr
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-background to-muted/20">
-            {/* Reading Progress Bar */}
-            <div className="fixed top-0 left-0 w-full h-1 bg-gradient-to-r from-muted/10 to-muted/30 z-50 shadow-sm">
+            <div aria-hidden="true" className="fixed top-0 left-0 w-full h-1 bg-gradient-to-r from-muted/10 to-muted/30 z-50 shadow-sm">
                 <motion.div
                     className="h-full bg-gradient-brand shadow-lg shadow-primary/20"
                     style={{ width: `${readingProgress}%` }}

--- a/Source/Client/src/app/blog/layout.tsx
+++ b/Source/Client/src/app/blog/layout.tsx
@@ -7,7 +7,7 @@ export default function BlogLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="flex min-h-[100dvh] flex-col bg-background text-foreground">
       <SiteHeader />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" className="flex-1">{children}</main>
       <SiteFooter />
     </div>
   );

--- a/Source/Client/src/app/layout.tsx
+++ b/Source/Client/src/app/layout.tsx
@@ -59,6 +59,12 @@ export default function RootLayout({
               "(function(){try{var t=localStorage.getItem('pm-theme');if(t&&t!=='default'){document.documentElement.classList.add(t);}}catch(e){}})();",
           }}
         />
+        <a
+          href="#main-content"
+          className="skip-link glass rounded-full px-4 py-2 text-sm font-medium text-foreground shadow-lg"
+        >
+          Skip to content
+        </a>
         <ThemeProvider attribute="class" forcedTheme="dark">
           {children}
         </ThemeProvider>

--- a/Source/Client/src/components/mobile-menu.tsx
+++ b/Source/Client/src/components/mobile-menu.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import Link from "next/link";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { X, Twitter, Linkedin, Github, Globe } from "lucide-react";
+
+export type MobileNavLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+  icon?: React.ComponentType<{ className?: string }>;
+};
+
+const socials = [
+  { label: "X / Twitter", href: "https://www.twitter.com/michael_wise", icon: Twitter },
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/michaelleahywise/", icon: Linkedin },
+  { label: "GitHub", href: "https://github.com/wisejnrs/pushmanifesto", icon: Github },
+  { label: "wisejnrs.net", href: "https://www.wisejnrs.net", icon: Globe },
+];
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function MobileMenu({
+  open,
+  onClose,
+  nav,
+}: {
+  open: boolean;
+  onClose: () => void;
+  nav: MobileNavLink[];
+}) {
+  const [mounted, setMounted] = React.useState(false);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const previouslyFocused = React.useRef<HTMLElement | null>(null);
+  const reduce = useReducedMotion();
+
+  React.useEffect(() => setMounted(true), []);
+
+  // Lock body scroll, trap focus, restore focus on close, close on Escape.
+  React.useEffect(() => {
+    if (!open) return;
+    previouslyFocused.current = document.activeElement as HTMLElement;
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+
+    // Focus the first focusable element in the panel.
+    const focusFirst = () => {
+      const nodes = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE);
+      nodes?.[0]?.focus();
+    };
+    const t = window.setTimeout(focusFirst, 50);
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const nodes = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE);
+      if (!nodes || nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = overflow;
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            initial={reduce ? { opacity: 1 } : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={reduce ? { opacity: 1 } : { opacity: 0 }}
+            className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm md:hidden"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+          <div className="pointer-events-none fixed inset-0 z-[101] flex items-start justify-center p-4 pt-20 md:hidden">
+            <motion.div
+              ref={panelRef}
+              id="mobile-menu"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Site menu"
+              initial={reduce ? { opacity: 1 } : { opacity: 0, scale: 0.94, y: -12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={reduce ? { opacity: 1 } : { opacity: 0, scale: 0.96, y: -8 }}
+              transition={{ type: "spring", stiffness: 280, damping: 24 }}
+              className="glass pointer-events-auto w-full max-w-sm overflow-hidden rounded-3xl p-5 shadow-[0_30px_70px_-24px_rgba(0,0,0,0.7)]"
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <span className="flex items-center gap-2.5">
+                  <img src="/assets/manifesto-ico.svg" alt="" aria-hidden className="h-7 w-7" />
+                  <span className="font-display text-base font-semibold tracking-tight">
+                    Push Manifesto
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close menu"
+                  className="grid h-9 w-9 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground active:scale-95"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <nav aria-label="Mobile" className="flex flex-col">
+                {nav.map((item) => (
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    target={item.external ? "_blank" : undefined}
+                    rel={item.external ? "noopener noreferrer" : undefined}
+                    onClick={onClose}
+                    className="flex items-center gap-3 rounded-xl px-3 py-3 text-[15px] font-medium text-foreground/90 transition-colors hover:bg-foreground/5"
+                  >
+                    {item.icon ? (
+                      <item.icon className="h-[18px] w-[18px] text-muted-foreground" />
+                    ) : (
+                      <span className="h-1.5 w-1.5 rounded-full bg-gradient-brand" />
+                    )}
+                    <span className="flex-1">{item.label}</span>
+                    {item.external && (
+                      <span className="sr-only">(opens in a new tab)</span>
+                    )}
+                  </Link>
+                ))}
+              </nav>
+
+              <div className="mt-3 flex items-center justify-center gap-1.5 border-t border-border/60 pt-4">
+                {socials.map((s) => (
+                  <Link
+                    key={s.label}
+                    href={s.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={onClose}
+                    aria-label={`${s.label} (opens in a new tab)`}
+                    className="grid h-9 w-9 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                  >
+                    <s.icon className="h-[18px] w-[18px]" />
+                  </Link>
+                ))}
+              </div>
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/Source/Client/src/components/quotes-marquee.tsx
+++ b/Source/Client/src/components/quotes-marquee.tsx
@@ -20,6 +20,7 @@ export function QuotesMarquee({ quotes }: { quotes: Quote[] }) {
         {row.map((q, i) => (
           <figure
             key={i}
+            aria-hidden={i >= quotes.length ? "true" : undefined}
             className="glass flex w-[320px] shrink-0 flex-col justify-between gap-4 rounded-2xl p-6 shadow-[0_1px_2px_rgba(16,24,40,0.04),0_16px_40px_-20px_rgba(16,24,40,0.35)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_2px_6px_rgba(16,24,40,0.06),0_28px_56px_-24px_rgba(16,24,40,0.45)]"
           >
             <blockquote className="font-display text-[17px] leading-snug text-foreground/90">

--- a/Source/Client/src/components/site-header.tsx
+++ b/Source/Client/src/components/site-header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Github, BookOpen, Store, Menu, X } from "lucide-react";
 
 import { ThemeSwitcher } from "@/components/theme-switcher";
+import { MobileMenu } from "@/components/mobile-menu";
 import { cn } from "@/lib/utils";
 
 type NavLink = {
@@ -55,7 +56,7 @@ export function SiteHeader() {
           </span>
         </Link>
 
-        <nav className="hidden items-center gap-1 md:flex">
+        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
           {NAV.map((item) => (
             <Link
               key={item.label}
@@ -65,9 +66,10 @@ export function SiteHeader() {
               className="rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
             >
               {item.label}
+              {item.external && <span className="sr-only"> (opens in a new tab)</span>}
             </Link>
           ))}
-          <span className="mx-1 h-5 w-px bg-border" />
+          <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
           <ThemeSwitcher />
         </nav>
 
@@ -75,35 +77,19 @@ export function SiteHeader() {
           <ThemeSwitcher />
           <button
             type="button"
-            aria-label="Toggle menu"
+            aria-label={open ? "Close menu" : "Open menu"}
             aria-expanded={open}
+            aria-haspopup="dialog"
+            aria-controls="mobile-menu"
             onClick={() => setOpen((v) => !v)}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/70 text-foreground active:scale-95"
+            className="grid h-9 w-9 place-items-center rounded-full border border-border/70 text-foreground transition-colors hover:bg-foreground/10 active:scale-95"
           >
             {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
           </button>
         </div>
       </div>
 
-      {open && (
-        <nav className="border-t border-border/60 bg-background/95 backdrop-blur-xl md:hidden">
-          <div className="container flex flex-col py-2">
-            {NAV.map((item) => (
-              <Link
-                key={item.label}
-                href={item.href}
-                target={item.external ? "_blank" : undefined}
-                rel={item.external ? "noopener noreferrer" : undefined}
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                {item.icon ? <item.icon className="h-4 w-4" /> : null}
-                {item.label}
-              </Link>
-            ))}
-          </div>
-        </nav>
-      )}
+      <MobileMenu open={open} onClose={() => setOpen(false)} nav={NAV} />
     </header>
   );
 }

--- a/Source/Client/src/styles/globals.css
+++ b/Source/Client/src/styles/globals.css
@@ -126,6 +126,27 @@
     scroll-behavior: smooth;
     -webkit-text-size-adjust: 100%;
   }
+  /* Visible, consistent keyboard focus for every interactive element
+     (WCAG 2.4.7). Modern browsers follow border-radius for outline. */
+  :where(a, button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="tab"], input, select, textarea, summary, [tabindex]:not([tabindex="-1"]))::-moz-focus-inner {
+    border: 0;
+  }
+  :where(a, button, [role="button"], [role="menuitem"], [role="menuitemradio"], [role="tab"], input, select, textarea, summary, [tabindex]:not([tabindex="-1"])):focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+  /* Skip-to-content link: off-screen until focused. */
+  .skip-link {
+    position: fixed;
+    top: 0.75rem;
+    left: 0.75rem;
+    z-index: 200;
+    transform: translateY(-200%);
+    transition: transform 0.2s ease;
+  }
+  .skip-link:focus {
+    transform: translateY(0);
+  }
   body {
     @apply bg-background text-foreground antialiased;
     text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Accessibility
- **Visible keyboard focus** on every interactive element (WCAG 2.4.7) — custom buttons/links had none.
- **Skip to content** link (2.4.1) on all layouts.
- **Nav landmarks labelled**; decorative dividers, blog reading-progress bar, and duplicated marquee quotes marked `aria-hidden` (1.3.1).
- External links announce **"(opens in a new tab)"**.

## Mobile menu (ported from wisejnrs.net)
- Centered **glass popup** via portal + framer-motion, replacing the inline dropdown.
- Hardened: `role="dialog"` + `aria-modal`, **focus trap**, **Escape** to close, **body scroll-lock**, focus returned to the trigger on close, reduced-motion aware.

Verified with headless Chrome at 390px: popup renders, `role=dialog`, focus moves into the panel on open. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)