### PR TITLE
Fix: Voices quote cards clipped by marquee overflow

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/quotes-marquee.tsx
+++ b/Source/Client/src/components/quotes-marquee.tsx
@@ -8,7 +8,7 @@ export function QuotesMarquee({ quotes }: { quotes: Quote[] }) {
 
   return (
     <div
-      className="group relative flex overflow-hidden"
+      className="group relative flex overflow-hidden py-6"
       style={{
         maskImage:
           "linear-gradient(to right, transparent, black 8%, black 92%, transparent)",


### PR DESCRIPTION
The marquee's `overflow-hidden` had no vertical room, so the quote cards' tops/shadows/hover-lift were cut off. Added `py-6` to the marquee track. Verified desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)