### PR TITLE
Complete Open Graph / Twitter / SEO metadata (v1.8.0)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/layout.tsx
+++ b/Source/Client/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { routing } from "@/i18n/routing";
+import { siteConfig } from "@/lib/site";
 import "@/styles/globals.css";
 
 const display = Bricolage_Grotesque({
@@ -30,16 +31,52 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
+  const ogLocale: Record<string, string> = {
+    en: "en_US",
+    es: "es_ES",
+    fr: "fr_FR",
+    de: "de_DE",
+    zh: "zh_CN",
+    ja: "ja_JP",
+  };
   return {
     metadataBase: new URL(
-      process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pushmanifesto.org",
+      process.env.NEXT_PUBLIC_SITE_URL ?? siteConfig.url,
     ),
-    title: { default: t("title"), template: "%s · Push Manifesto" },
+    title: { default: t("title"), template: `%s · ${siteConfig.name}` },
     description: t("description"),
+    applicationName: siteConfig.name,
+    keywords: siteConfig.keywords,
+    authors: [{ name: siteConfig.author.name }],
+    creator: siteConfig.creator.name,
+    publisher: siteConfig.creator.name,
+    alternates: { canonical: "/" },
     icons: {
       icon: "/assets/manifesto-ico.svg",
       shortcut: "/assets/manifesto-ico.svg",
       apple: "/assets/manifesto-ico.svg",
+    },
+    openGraph: {
+      type: "website",
+      siteName: siteConfig.name,
+      title: t("title"),
+      description: t("description"),
+      url: siteConfig.url,
+      locale: ogLocale[locale] ?? "en_US",
+      images: [{ url: siteConfig.ogImage, width: 1280, height: 641, alt: siteConfig.name }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("title"),
+      description: t("description"),
+      site: siteConfig.social.handles.x,
+      creator: siteConfig.social.handles.x,
+      images: [siteConfig.ogImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true, "max-image-preview": "large" },
     },
   };
 }

--- a/Source/Client/src/lib/site.ts
+++ b/Source/Client/src/lib/site.ts
@@ -4,7 +4,7 @@ export const siteConfig = {
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pushmanifesto.org",
   description: "A way to do creativity — principles for innovation and progress.",
   tagline: "A way to do creativity",
-  ogImage: "/assets/manifesto-ico.svg",
+  ogImage: "/img/manifesto-social.png",
   keywords: [
     "Push Manifesto",
     "innovation",


### PR DESCRIPTION
## What & why

Audit follow-up: ensure **meta, keywords and Open Graph all work**. Push Manifesto already had comprehensive **security headers + CSP** (`next.config.mjs`), but the page metadata was missing social-sharing tags — and the `ogImage` pointed at an **SVG**, which most platforms won't render in link previews.

## Changes

- **Open Graph** — `type`, `siteName`, `title`, `description`, `url`, `locale`, and a proper raster image (`img/manifesto-social.png`, 1280×641, the "Push Manifesto" astronaut card) replacing the SVG.
- **Twitter** — `summary_large_image` card with `@michael_wise` as site/creator.
- **keywords**, **canonical**, **robots/googleBot** (`max-image-preview: large`), `authors`/`creator`/`publisher`, `applicationName` — all sourced from `lib/site.ts`.

## Verified

- `npm run build` ✓ (22 static pages).
- Local prod head check confirms `og:*`, `twitter:*`, `keywords`, and `canonical` all render with absolute image URLs.
- Security headers/CSP unchanged (already complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)