### PR TITLE
feat(seo): Open Graph metadata + crawler/AI-SEO surfaces

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/public/llms.txt
+++ b/Source/Client/public/llms.txt
@@ -1,0 +1,15 @@
+# Push Manifesto
+
+> The Push Manifesto is a short philosophy of creative work by Michael Wise — "a way to do creativity." It argues for prioritising the journey over the destination and frames innovation as a series of deliberate "pushes": evidence-led, hypothesis-driven, tolerant of ambiguity and risk, and honest about getting things wrong. The manifesto and the long-form thinking behind it live at www.pushmanifesto.org.
+
+## Read
+- [Manifesto](https://www.pushmanifesto.org/#manifesto): the core text — prioritise the journey, then act through deliberate pushes.
+- [Principles](https://www.pushmanifesto.org/#principles): the building blocks of a push — Push, Ambiguity & Cognitive Bias, Risk, Check-ins/Waypoints/Reviews, Identify & Remove Road Blocks, Creating Shared Value, Mise en place, Work Items, Getting it Wrong, Go Find Out, Know when to Roll 'Em, and Hypothesis (an idea doesn't exist if it can't be tested).
+- [Blog](https://www.pushmanifesto.org/blog): essays expanding on the manifesto, starting with "Journey over Destination."
+- [Blog RSS feed](https://www.pushmanifesto.org/feed.xml): subscribe in any reader.
+
+## About
+- Author: Michael Wise — technology leader writing about creativity, delivery, and the Push philosophy.
+- Themes: innovation, creativity, product delivery, ways of working, evidence-based and scientific thinking.
+- Source: https://github.com/wisejnrs/pushmanifesto (and project wiki).
+- A WiseJNRS project (https://www.wisejnrs.net).

--- a/Source/Client/src/app/[locale]/layout.tsx
+++ b/Source/Client/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { routing } from "@/i18n/routing";
+import { siteConfig } from "@/lib/site";
 import "@/styles/globals.css";
 
 const display = Bricolage_Grotesque({
@@ -30,16 +31,52 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
+  const ogLocale: Record<string, string> = {
+    en: "en_US",
+    es: "es_ES",
+    fr: "fr_FR",
+    de: "de_DE",
+    zh: "zh_CN",
+    ja: "ja_JP",
+  };
   return {
     metadataBase: new URL(
-      process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pushmanifesto.org",
+      process.env.NEXT_PUBLIC_SITE_URL ?? siteConfig.url,
     ),
-    title: { default: t("title"), template: "%s · Push Manifesto" },
+    title: { default: t("title"), template: `%s · ${siteConfig.name}` },
     description: t("description"),
+    applicationName: siteConfig.name,
+    keywords: siteConfig.keywords,
+    authors: [{ name: siteConfig.author.name }],
+    creator: siteConfig.creator.name,
+    publisher: siteConfig.creator.name,
+    alternates: { canonical: "/" },
     icons: {
       icon: "/assets/manifesto-ico.svg",
       shortcut: "/assets/manifesto-ico.svg",
       apple: "/assets/manifesto-ico.svg",
+    },
+    openGraph: {
+      type: "website",
+      siteName: siteConfig.name,
+      title: t("title"),
+      description: t("description"),
+      url: siteConfig.url,
+      locale: ogLocale[locale] ?? "en_US",
+      images: [{ url: siteConfig.ogImage, width: 1280, height: 641, alt: siteConfig.name }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("title"),
+      description: t("description"),
+      site: siteConfig.social.handles.x,
+      creator: siteConfig.social.handles.x,
+      images: [siteConfig.ogImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true, "max-image-preview": "large" },
     },
   };
 }

--- a/Source/Client/src/app/feed.xml/route.ts
+++ b/Source/Client/src/app/feed.xml/route.ts
@@ -1,10 +1,10 @@
-import { getAllPosts, generateRSSFeed } from "@/lib/blog";
+import { getPublishedPostsServer, generateRSSFeedServer } from "@/lib/blog-server";
 import { siteConfig } from "@/lib/site";
 
 export const revalidate = 3600;
 
 export function GET() {
-  const xml = generateRSSFeed(getAllPosts(), siteConfig);
+  const xml = generateRSSFeedServer(getPublishedPostsServer(), siteConfig);
   return new Response(xml, {
     headers: {
       "Content-Type": "application/rss+xml; charset=utf-8",

--- a/Source/Client/src/app/manifest.ts
+++ b/Source/Client/src/app/manifest.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Push Manifesto",
+    short_name: "Push Manifesto",
+    description: "A way to do creativity — principles for innovation and progress.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#05070d",
+    theme_color: "#0b1020",
+    icons: [
+      { src: "/assets/manifesto-ico.svg", sizes: "any", type: "image/svg+xml", purpose: "any" },
+    ],
+  };
+}

--- a/Source/Client/src/app/robots.ts
+++ b/Source/Client/src/app/robots.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from "next";
+import { siteConfig } from "@/lib/site";
+
+// Open to all crawlers, including AI search/answer engines — public writing we
+// want discoverable and citable. Only /api is excluded.
+export default function robots(): MetadataRoute.Robots {
+  const url = siteConfig.url;
+  return {
+    rules: [
+      {
+        userAgent: [
+          "GPTBot", "OAI-SearchBot", "ChatGPT-User", "ClaudeBot", "anthropic-ai",
+          "Claude-Web", "PerplexityBot", "Google-Extended", "CCBot",
+          "Applebot-Extended", "Amazonbot", "cohere-ai", "Meta-ExternalAgent", "YouBot",
+        ],
+        allow: "/",
+        disallow: "/api/",
+      },
+      { userAgent: "*", allow: "/", disallow: "/api/" },
+    ],
+    sitemap: `${url}/sitemap.xml`,
+    host: url,
+  };
+}

--- a/Source/Client/src/app/sitemap.ts
+++ b/Source/Client/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from "next";
+import { siteConfig } from "@/lib/site";
+import { getPublishedPostsServer } from "@/lib/blog-server";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = siteConfig.url;
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: base, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${base}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+  ];
+
+  let posts: MetadataRoute.Sitemap = [];
+  try {
+    posts = getPublishedPostsServer().map((p) => ({
+      url: `${base}/blog/${p.slug}`,
+      lastModified: new Date(p.publishedAt),
+      changeFrequency: "monthly",
+      priority: p.featured ? 0.8 : 0.6,
+    }));
+  } catch {}
+
+  return [...staticRoutes, ...posts];
+}

--- a/Source/Client/src/lib/site.ts
+++ b/Source/Client/src/lib/site.ts
@@ -4,7 +4,7 @@ export const siteConfig = {
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pushmanifesto.org",
   description: "A way to do creativity — principles for innovation and progress.",
   tagline: "A way to do creativity",
-  ogImage: "/assets/manifesto-ico.svg",
+  ogImage: "/img/manifesto-social.png",
   keywords: [
     "Push Manifesto",
     "innovation",


### PR DESCRIPTION
## Summary
Completes SEO + AI-SEO for pushmanifesto.org.

**Discoverability / social (v1.8.0 work, folded in):**
- Full Open Graph / Twitter card metadata

**Crawler + AI-SEO surfaces (v1.9.0):**
- **robots.ts** — allows AI search/answer crawlers (GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot, …), disallows `/api/`, declares sitemap + host
- **sitemap.ts** — home + `/blog` + blog posts (locale-aware reader)
- **manifest.ts** — PWA manifest (name, dark theme/bg, SVG icon)
- **public/llms.txt** — llms.txt-spec summary of the manifesto + principles for AI agents
- **Fix:** `feed.xml` now reads posts via `getPublishedPostsServer` (was reading the flat dir → empty RSS)

## Verification
- `npm run build` compiles clean; `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest`, `/feed.xml` all prerender; `llms.txt` served statically
- Middleware matcher excludes dotted paths, so all serve from root without a locale prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)