### PR TITLE
fix(motion): align Reveal with shared WiseJNRS entrance

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/reveal.tsx
+++ b/Source/Client/src/components/reveal.tsx
@@ -24,9 +24,9 @@ export function Reveal({ children, delay = 0, className, as = "div" }: RevealPro
   return (
     <Comp
       className={className}
-      initial={{ opacity: 0, y: 18 }}
+      initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "-80px" }}
+      viewport={{ once: true }}
       transition={{ duration: 0.6, delay, ease: [0.22, 1, 0.36, 1] }}
     >
       {children}


### PR DESCRIPTION
## Summary
The main page's below-hero sections (manifesto, principles, voices, CTA) sat blank too long on load — the `Reveal` component used a `-80px` viewport margin, so reveals near the viewport edge fired late compared to the other sites.

- Removes the `-80px` margin and matches **wisejnrs-website's** exact entrance: `initial {opacity:0, y:20}` → `whileInView {opacity:1, y:0}`, `viewport {once:true}`, reduced-motion → static-visible.
- Part of unifying the entrance animation across wisejnrs-website, pushmanifesto, and spacewelders.

## Verification
- `npm run build` compiles clean
- Reveals now fire as content enters the viewport (verified via scroll on the deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)