### PR TITLE
fix: drop Speed Insights (Hobby single-project limit)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/layout.tsx
+++ b/Source/Client/src/app/[locale]/layout.tsx
@@ -6,7 +6,6 @@ import { Bricolage_Grotesque } from "next/font/google";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { routing } from "@/i18n/routing";
@@ -130,7 +129,6 @@ export default async function LocaleLayout({
           </ThemeProvider>
         </NextIntlClientProvider>
         <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
Speed Insights is enabled only on wisejnrs-website (the main site). On the Hobby plan it's limited to one project, so `/_vercel/speed-insights/script.js` 404'd here and threw a MIME error in the console.

- Remove `<SpeedInsights/>` from the layout
- Keep `<Analytics/>` (Web Analytics — free across projects on Hobby; enable it for this project in the Vercel dashboard to clear its 404 too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)