### PR TITLE
fix: remove Vercel Analytics (404 in console, not enabled here)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/layout.tsx
+++ b/Source/Client/src/app/[locale]/layout.tsx
@@ -5,7 +5,6 @@ import { getMessages, getTranslations, setRequestLocale } from "next-intl/server
 import { Bricolage_Grotesque } from "next/font/google";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import { Analytics } from "@vercel/analytics/next";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { routing } from "@/i18n/routing";
@@ -128,7 +127,6 @@ export default async function LocaleLayout({
             {children}
           </ThemeProvider>
         </NextIntlClientProvider>
-        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
Web Analytics isn't enabled for this Vercel project, so `<Analytics/>` kept 404ing on `/_vercel/insights/script.js`. Removed it; combined with the earlier Speed Insights removal, the site loads no Vercel analytics scripts and the console is clean. Analytics stays on wisejnrs-website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)