### PR TITLE
fix: render content even if JS fails (CSS reveal, not whileInView)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/reveal.tsx
+++ b/Source/Client/src/components/reveal.tsx
@@ -1,33 +1,25 @@
-"use client";
-
 import * as React from "react";
-import { motion, useReducedMotion } from "framer-motion";
 
 type RevealProps = {
   children: React.ReactNode;
   delay?: number;
   className?: string;
   /** Render as something other than a div (e.g. "li", "section"). */
-  as?: keyof typeof motion;
+  as?: React.ElementType;
 };
 
+// Entrance reveal driven by a pure-CSS animation (`.reveal-up` in globals.css),
+// NOT a JS scroll-observer. Content is therefore never gated on hydration: if
+// the JS bundle fails to load (e.g. a stale cache hitting 404'd chunks after a
+// deploy) the page still shows — the CSS animation runs on load and ends
+// visible. `delay` (seconds) staggers siblings via animation-delay; the
+// prefers-reduced-motion rule collapses it to an instant show.
 export function Reveal({ children, delay = 0, className, as = "div" }: RevealProps) {
-  const reduce = useReducedMotion();
-  const Comp = motion[as] as typeof motion.div;
-
-  // Reduced motion: render static, fully-visible content (no enter animation).
-  if (reduce) {
-    const Plain = as as React.ElementType;
-    return <Plain className={className}>{children}</Plain>;
-  }
-
+  const Comp = as;
   return (
     <Comp
-      className={className}
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.6, delay, ease: [0.22, 1, 0.36, 1] }}
+      className={["reveal-up", className].filter(Boolean).join(" ")}
+      style={delay ? { animationDelay: `${delay}s` } : undefined}
     >
       {children}
     </Comp>

--- a/Source/Client/src/styles/globals.css
+++ b/Source/Client/src/styles/globals.css
@@ -346,3 +346,17 @@
     scroll-behavior: auto !important;
   }
 }
+
+/* Entrance reveal — fade + rise that runs once on load. Pure CSS (driven by
+   the Reveal component) so content is never gated on JS hydration: if the
+   bundle fails to load (e.g. a stale cache after a deploy) the animation still
+   runs and the content ends visible. `animation-fill-mode: both` + the
+   reduced-motion rule above guarantee the final, visible state. Per-element
+   stagger comes from an inline `animation-delay`. */
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: none; }
+}
+.reveal-up {
+  animation: reveal-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}


### PR DESCRIPTION
## Problem
The home page shipped **24 elements as `opacity:0;transform:translateY(20px)`** (framer-motion `initial`), revealed only once the JS `whileInView` observer ran. After a deploy, a **stale browser cache** loading now-404'd JS chunks means hydration never happens → the reveal never fires → **the whole page renders blank except the astronaut image** (it's a plain `<img>`). Screenshot confirmed.

## Fix
Rewrite `Reveal` to a **pure-CSS `.reveal-up` animation** (runs on load, no JS dependency). `animation-fill-mode: both` + the existing `prefers-reduced-motion` rule guarantee the visible end state. Same fade-up look; content can never be gated blank by a JS failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)