### PR TITLE
feat(header): glassmorphism + centered nav (match wisejnrs)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/site-header.tsx
+++ b/Source/Client/src/components/site-header.tsx
@@ -8,7 +8,6 @@ import { Link } from "@/i18n/navigation";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { MobileMenu } from "@/components/mobile-menu";
-import { cn } from "@/lib/utils";
 
 export type NavItem = {
   key: string;
@@ -27,69 +26,58 @@ export const NAV: NavItem[] = [
 
 export function SiteHeader() {
   const t = useTranslations();
-  const [scrolled, setScrolled] = React.useState(false);
   const [open, setOpen] = React.useState(false);
 
-  React.useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 8);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+  const navLinkClass =
+    "rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors duration-200 hover:bg-foreground/10 hover:text-foreground";
+
+  const logo = (
+    <Link href="/" className="group flex shrink-0 items-center gap-2.5">
+      <img
+        src="/assets/manifesto-ico.svg"
+        alt=""
+        aria-hidden
+        className="h-8 w-8 shrink-0 transition-transform duration-300 group-hover:rotate-[8deg]"
+      />
+      <span className="whitespace-nowrap font-display text-lg font-semibold tracking-tight">
+        Push Manifesto
+      </span>
+    </Link>
+  );
+
+  const navLinks = NAV.map((item) =>
+    item.external ? (
+      <a
+        key={item.key}
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={navLinkClass}
+      >
+        {t(`nav.${item.key}`)}
+        <span className="sr-only"> {t("common.newTab")}</span>
+      </a>
+    ) : (
+      <Link key={item.key} href={item.href} className={navLinkClass}>
+        {t(`nav.${item.key}`)}
+      </Link>
+    ),
+  );
+
+  const controls = (
+    <>
+      <LanguageSwitcher />
+      <ThemeSwitcher />
+    </>
+  );
 
   return (
-    <header
-      className={cn(
-        "sticky top-0 z-40 w-full transition-colors duration-300",
-        scrolled
-          ? "border-b border-border/60 bg-background/80 backdrop-blur-xl"
-          : "border-b border-transparent bg-background/0",
-      )}
-    >
-      <div className="container flex h-16 items-center justify-between gap-2">
-        <Link href="/" className="group flex shrink-0 items-center gap-2.5">
-          <img
-            src="/assets/manifesto-ico.svg"
-            alt=""
-            aria-hidden
-            className="h-8 w-8 shrink-0 transition-transform duration-300 group-hover:rotate-[8deg]"
-          />
-          <span className="whitespace-nowrap font-display text-lg font-semibold tracking-tight">
-            Push Manifesto
-          </span>
-        </Link>
-
-        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
-          {NAV.map((item) =>
-            item.external ? (
-              <a
-                key={item.key}
-                href={item.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
-              >
-                {t(`nav.${item.key}`)}
-                <span className="sr-only"> {t("common.newTab")}</span>
-              </a>
-            ) : (
-              <Link
-                key={item.key}
-                href={item.href}
-                className="rounded-full px-3 py-1.5 text-sm text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-foreground"
-              >
-                {t(`nav.${item.key}`)}
-              </Link>
-            ),
-          )}
-          <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
-          <LanguageSwitcher />
-          <ThemeSwitcher />
-        </nav>
-
-        <div className="flex items-center gap-1.5 md:hidden">
-          <LanguageSwitcher />
-          <ThemeSwitcher />
+    <header className="sticky top-0 z-40 w-full border-b border-white/10 bg-background/20 shadow-lg shadow-black/5 backdrop-blur-xl supports-[backdrop-filter]:bg-background/20 relative before:pointer-events-none before:absolute before:inset-0 before:bg-gradient-to-r before:from-transparent before:via-white/5 before:to-transparent">
+      {/* Mobile / tablet (< lg): logo left, controls + menu right */}
+      <div className="container flex h-16 items-center justify-between gap-2 lg:hidden">
+        {logo}
+        <div className="flex items-center gap-1.5">
+          {controls}
           <button
             type="button"
             aria-label={open ? t("common.closeMenu") : t("common.openMenu")}
@@ -101,6 +89,18 @@ export function SiteHeader() {
           >
             {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
           </button>
+        </div>
+      </div>
+
+      {/* Desktop (lg+): logo left · centered nav · controls right */}
+      <div className="container hidden h-16 grid-cols-3 items-center gap-2 lg:grid">
+        <div className="flex items-center justify-start">{logo}</div>
+        <nav aria-label="Primary" className="flex items-center justify-center gap-1">
+          {navLinks}
+        </nav>
+        <div className="flex items-center justify-end gap-1">
+          <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+          {controls}
         </div>
       </div>
 


### PR DESCRIPTION
Reworks the header to match wisejnrs-website: always-on glassmorphism (backdrop-blur, `white/10` border, soft shadow, gradient sheen) and a **3-column desktop layout with the nav centered** (logo left · menu centre · controls right) at `lg+`. Mobile/tablet keeps logo + controls + hamburger. Drops the scroll-triggered glass toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)