### PR TITLE
feat(seo): homepage structured data (WebSite + Organization)

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/(public)/page.tsx
+++ b/Source/Client/src/app/[locale]/(public)/page.tsx
@@ -6,6 +6,7 @@ import { ArrowDown, ArrowRight, ArrowUpRight } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { Reveal } from "@/components/reveal";
 import { FeaturedProducts } from "@/components/featured-products";
+import { siteConfig } from "@/lib/site";
 import { QuotesMarquee, type Quote } from "@/components/quotes-marquee";
 import { HeroAstronaut } from "@/components/hero-astronaut";
 import { MagneticButton } from "@/components/magnetic-button";
@@ -86,8 +87,34 @@ export default async function HomePage({
   setRequestLocale(locale);
   const t = await getTranslations();
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        name: siteConfig.name,
+        url: siteConfig.url,
+        description: siteConfig.description,
+        inLanguage: "en",
+      },
+      {
+        "@type": "Organization",
+        name: siteConfig.name,
+        url: siteConfig.url,
+        logo: `${siteConfig.url}/assets/manifesto-ico.svg`,
+        description: siteConfig.description,
+        founder: { "@type": "Person", name: siteConfig.creator.name, url: siteConfig.creator.linkedin },
+        sameAs: [siteConfig.links.github, siteConfig.links.linkedin, siteConfig.links.x].filter(Boolean),
+      },
+    ],
+  };
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <Script
         src="https://www.googletagmanager.com/gtag/js?id=G-VZ3GBPF421"
         strategy="afterInteractive"


### PR DESCRIPTION
The homepage shipped **no JSON-LD**. Adds an accurate `@graph` (WebSite + Organization with founder Michael Wise and GitHub/LinkedIn/X `sameAs`) so search + AI engines can resolve and attribute the site. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)