### PR TITLE
fix(home): tighten Voices heading-to-quotes spacing

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/(public)/page.tsx
+++ b/Source/Client/src/app/[locale]/(public)/page.tsx
@@ -263,8 +263,8 @@ gtag('config', 'G-VZ3GBPF421');`}
       </section>
 
       {/* ───────────────────── Voices / quotes ───────────────────── */}
-      <section className="border-y border-border/60 bg-muted/50">
-        <div className="container py-14 md:py-20">
+      <section className="border-y border-border/60 bg-muted/50 py-14 md:py-20">
+        <div className="container">
           <Reveal>
             <Eyebrow>{t("voices.eyebrow")}</Eyebrow>
             <h2 className="mt-5 max-w-2xl font-display text-3xl font-semibold tracking-tight md:text-4xl">
@@ -272,7 +272,7 @@ gtag('config', 'G-VZ3GBPF421');`}
             </h2>
           </Reveal>
         </div>
-        <Reveal className="pb-14 md:pb-20">
+        <Reveal className="mt-8 md:mt-10">
           <QuotesMarquee quotes={quotes} />
         </Reveal>
       </section>


### PR DESCRIPTION
The Voices heading ("Small things, more often.") sat ~6.5rem above its quote marquee — the heading block had `py-20` and the marquee was a separate padded block, leaving an awkward empty band (flagged on the main page). Moved padding to the section and set the marquee to `mt-8 md:mt-10` so the heading and cards read as one unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)