### PR TITLE
fix(home): Featured Products full container width

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/featured-products.tsx
+++ b/Source/Client/src/components/featured-products.tsx
@@ -22,7 +22,7 @@ const STORE_URL = "https://wisejnrs.myshopify.com";
 
 export function FeaturedProducts() {
   return (
-    <section className="container max-w-5xl px-6 py-16 md:py-24">
+    <section className="container py-16 md:py-24">
       <div className="mb-8 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
         <div>
           <h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">Featured Products</h2>


### PR DESCRIPTION
Featured Products was `max-w-5xl` while every other home section (hero, manifesto, principles, voices, CTA) uses the full `container` — so it was visibly narrower than the section above. Dropped the `max-w-5xl px-6` overrides to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)