### PR TITLE
fix(ui): readable scrollable palette picker

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/components/theme-switcher.tsx
+++ b/Source/Client/src/components/theme-switcher.tsx
@@ -80,7 +80,7 @@ export function ThemeSwitcher() {
       {open && (
         <div
           role="menu"
-          className="glass absolute right-0 z-50 mt-2 w-56 origin-top-right rounded-2xl p-1.5 shadow-[0_24px_50px_-20px_rgba(0,0,0,0.6)]"
+          className="menu-scroll absolute right-0 z-50 mt-2 max-h-[min(70vh,24rem)] w-56 origin-top-right overflow-y-auto rounded-2xl border border-border/60 bg-card/95 p-1.5 shadow-[0_24px_50px_-20px_rgba(0,0,0,0.6)] backdrop-blur-xl"
         >
           <p className="px-2.5 pb-1 pt-1.5 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
             Palette

--- a/Source/Client/src/styles/globals.css
+++ b/Source/Client/src/styles/globals.css
@@ -436,3 +436,27 @@
 .reveal-up {
   animation: reveal-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
+
+/* Scrollable menus (e.g. the palette picker): smooth scroll + a slim, themed
+   scrollbar that stays out of the way until you need it. */
+.menu-scroll {
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
+  overscroll-behavior: contain;
+}
+.menu-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+.menu-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.menu-scroll::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / 0.35);
+  border-radius: 9999px;
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+.menu-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.55);
+}


### PR DESCRIPTION
Palette picker was nearly see-through in dark mode (`.glass` = 5% opacity). Now opaque `bg-card/95`, plus `max-h` + smooth scroll + slim themed scrollbar (`.menu-scroll`) for the 13 palettes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)