### PR TITLE
feat(seo): env-driven Google Search Console verification

### DIFF
--- a/Source/Client/package.json
+++ b/Source/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushmanifesto",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "scripts": {
     "predev": "npm run clean",

--- a/Source/Client/src/app/[locale]/layout.tsx
+++ b/Source/Client/src/app/[locale]/layout.tsx
@@ -76,6 +76,9 @@ export async function generateMetadata({
       follow: true,
       googleBot: { index: true, follow: true, "max-image-preview": "large" },
     },
+    // Set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION in Vercel to emit the Search
+    // Console HTML-tag verification meta (omitted when unset).
+    verification: { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION },
   };
 }
 


### PR DESCRIPTION
Adds `verification.google` (from `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`) so Search Console HTML-tag verification is a one-step env-var action. Tag omitted when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)